### PR TITLE
stitch validate json relative path instead of python 3.5 virtual env hardcoded path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,14 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-onfleet
             source /usr/local/share/virtualenvs/tap-onfleet/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install -U pip setuptools
             pip install .[dev]
       - add_ssh_keys
       - run:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-onfleet/lib/python3.5/site-packages/tap_onfleet/schemas/*.json
+            stitch-validate-json tap_onfleet/schemas/*.json
 workflows:
   version: 2
   commit:


### PR DESCRIPTION
# Description of change
stitch validate json relative path instead of python 3.5 virtual env hardcoded path

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
